### PR TITLE
Make additional updates for 2023 competition

### DIFF
--- a/src/content/competition-details.json
+++ b/src/content/competition-details.json
@@ -282,8 +282,8 @@
     },
     "fee": "$10",
     "website": {
-      "name": "North Texas Brew Competition",
-      "url": "https://northtexas.brewcomp.com/"
+      "name": "North Texas Circuit Brew Competition",
+      "url": "https://ntc.brewcompetition.com/"
     },
     "additionalInformation": [
       "The Horsemen of the Hopocalypse will be hosting most of the events on the North Texas Homebrew Circuit, so this registration link will also be used for other homebrewing events throughout the year. The North Texas Brew Competition website will be updated for the Redcoat Challenge before registration opens.",

--- a/src/pages/competition/rules.js
+++ b/src/pages/competition/rules.js
@@ -150,8 +150,8 @@ const Rules = () => (
         </ul>
         <p>
           Recipes are not required. Judging style guidelines used will be the
-          2015 Beer Judge Certification Program Style Guidelines and the style
-          guidelines created by TRC for future categories not listed in the 2015
+          2021 Beer Judge Certification Program Style Guidelines and the style
+          guidelines created by TRC for future categories not listed in the 2021
           BJCP Style Guidelines. As per BJCP sanctioning requirements, judges
           may not judge a category that they have entered in themselves if they
           are also a competitor in the event. The style guidelines are available
@@ -160,7 +160,7 @@ const Rules = () => (
           <br />
           <br />
           Be meticulous about noting any special ingredients that must be
-          specified per the 2015 BJCP Style Guidelines. Categories with a number
+          specified per the 2021 BJCP Style Guidelines. Categories with a number
           of entries may be combined at the discretion of the competition
           organizers. The Competition Coordinator or other qualified person will
           review elements of beer categories and styles with each panel prior to


### PR DESCRIPTION
## Related Issues

- Resolves #19

## Changes

- Update `name` and `url` for registration website
- Update references to BJCP Guidelines to specify correct year